### PR TITLE
Add break timer functionality with automatic focus/break cycles

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,22 +9,35 @@
 <body>
     <div class="container">
         <h1>Focus Timer</h1>
-        <div class="timer-select" style="margin-bottom: 1rem;">
-            <label for="timerDropdown">Select duration: </label>
-            <select id="timerDropdown">
-                <option value="5">5 minutes</option>
-                <option value="10">10 minutes</option>
-                <option value="15">15 minutes</option>
-                <option value="20">20 minutes</option>
-                <option value="25" selected>25 minutes</option>
-                <option value="30">30 minutes</option>
-                <option value="35">35 minutes</option>
-                <option value="40">40 minutes</option>
-                <option value="45">45 minutes</option>
-                <option value="50">50 minutes</option>
-                <option value="55">55 minutes</option>
-                <option value="60">60 minutes</option>
-            </select>
+        <div class="timer-select" style="margin-bottom: 1rem; display: flex; gap: 1rem; justify-content: center;">
+            <div>
+                <label for="timerDropdown">Focus: </label>
+                <select id="timerDropdown">
+                    <option value="5">5 minutes</option>
+                    <option value="10">10 minutes</option>
+                    <option value="15">15 minutes</option>
+                    <option value="20">20 minutes</option>
+                    <option value="25" selected>25 minutes</option>
+                    <option value="30">30 minutes</option>
+                    <option value="35">35 minutes</option>
+                    <option value="40">40 minutes</option>
+                    <option value="45">45 minutes</option>
+                    <option value="50">50 minutes</option>
+                    <option value="55">55 minutes</option>
+                    <option value="60">60 minutes</option>
+                </select>
+            </div>
+            <div>
+                <label for="breakDropdown">Break: </label>
+                <select id="breakDropdown">
+                    <option value="5" selected>5 minutes</option>
+                    <option value="10">10 minutes</option>
+                    <option value="15">15 minutes</option>
+                    <option value="20">20 minutes</option>
+                    <option value="25">25 minutes</option>
+                    <option value="30">30 minutes</option>
+                </select>
+            </div>
         </div>
         <div class="timer-container">
             <div class="dog-icon">🐕</div>


### PR DESCRIPTION
What's new in this update:
Break timer dropdown (5-30 minutes) next to the focus timer dropdown
Automatic focus/break cycles - After focus ends, break starts automatically
Break encouragement messages - Motivational messages during break time
Seamless transitions - After break ends, timer resets to focus mode
Flexible duration selection - Change focus or break duration anytime
How it works:
Select your focus time (5-60 minutes)
Select your break time (5-30 minutes)
Press Start to begin focus session
When focus ends, break starts automatically with encouragement
When break ends, timer resets to focus mode, ready for another round